### PR TITLE
Fix JSON path in image conversion

### DIFF
--- a/src/art.py
+++ b/src/art.py
@@ -34,8 +34,7 @@ async def draw(prompt) -> str:
 
 # code stolen from https://realpython.com/generate-images-with-dalle-openai-api/
 async def convert(path):
-    DATA_DIR = Path.cwd() / "responses"
-    JSON_FILE = DATA_DIR / path
+    JSON_FILE = Path(path)
     IMAGE_DIR = Path.cwd() / "images"
     IMAGE_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -50,6 +49,6 @@ async def convert(path):
             png.write(image_data)
 
         # delete uneeded json file
-        os.remove(path)
+        os.remove(JSON_FILE)
 
     return image_file


### PR DESCRIPTION
## Summary
- fix path handling in `convert`

## Testing
- `python -m py_compile src/art.py src/aclient.py src/bot.py src/log.py src/personas.py src/responses.py main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e10e54eec8325915c63fc1db15b49